### PR TITLE
QuizService 구현체 구현

### DIFF
--- a/src/main/java/com/valanse/valanse/entity/Quiz.java
+++ b/src/main/java/com/valanse/valanse/entity/Quiz.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,5 +26,24 @@ public class Quiz {
     @Column(name = "description_b")
     private String descriptionB; // 선택지 B 설명
 
+    private Integer view; // 퀴즈의 조회수
+    private Integer comment; // 퀴즈의 댓글 수
+    private Integer preference; // 퀴즈의 선호도 수
+
     private LocalDateTime createdAt; // 퀴즈 생성 시간
+
+    // 조회수 증가
+    public void incrementViews() {
+        this.view++;
+    }
+
+    // 댓글 수 증가
+    public void incrementComments() {
+        this.comment++;
+    }
+
+    // 선호도 수 증가
+    public void incrementPreference(Integer preference) {
+        this.preference += preference;
+    }
 }

--- a/src/main/java/com/valanse/valanse/entity/Quiz.java
+++ b/src/main/java/com/valanse/valanse/entity/Quiz.java
@@ -27,23 +27,7 @@ public class Quiz {
     private String descriptionB; // 선택지 B 설명
 
     private Integer view; // 퀴즈의 조회수
-    private Integer comment; // 퀴즈의 댓글 수
     private Integer preference; // 퀴즈의 선호도 수
 
     private LocalDateTime createdAt; // 퀴즈 생성 시간
-
-    // 조회수 증가
-    public void incrementViews() {
-        this.view++;
-    }
-
-    // 댓글 수 증가
-    public void incrementComments() {
-        this.comment++;
-    }
-
-    // 선호도 수 증가
-    public void incrementPreference(Integer preference) {
-        this.preference += preference;
-    }
 }

--- a/src/main/java/com/valanse/valanse/repository/jpa/QuizRepository.java
+++ b/src/main/java/com/valanse/valanse/repository/jpa/QuizRepository.java
@@ -1,10 +1,18 @@
 package com.valanse.valanse.repository.jpa;
 
 import com.valanse.valanse.entity.Quiz;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface QuizRepository extends JpaRepository<Quiz, Integer> {
 
+    List<Quiz> findAllByOrderByCreatedAtDesc();
+
+    List<Quiz> findAllByOrderByPreferenceDesc();
+
+    List<Quiz> findByContentContaining(String keyword);
 }

--- a/src/main/java/com/valanse/valanse/repository/jpa/QuizRepository.java
+++ b/src/main/java/com/valanse/valanse/repository/jpa/QuizRepository.java
@@ -1,14 +1,22 @@
 package com.valanse.valanse.repository.jpa;
 
 import com.valanse.valanse.entity.Quiz;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface QuizRepository extends JpaRepository<Quiz, Integer> {
+
+    @Modifying
+    @Query("UPDATE  Quiz q SET q.view = q.view + 1 WHERE q.quizId = :quizId")
+    void increaseView(@Param("quizId") Integer quizId);
+
+    @Modifying
+    @Query("UPDATE Quiz q SET q.preference = q.preference + :preference WHERE q.quizId = :quizId")
+    void increasePreference(@Param("quizId") Integer quizId, @Param("preference") int preference);
 
     List<Quiz> findAllByOrderByCreatedAtDesc();
 

--- a/src/main/java/com/valanse/valanse/repository/jpa/UserAnswerRepository.java
+++ b/src/main/java/com/valanse/valanse/repository/jpa/UserAnswerRepository.java
@@ -1,7 +1,12 @@
 package com.valanse.valanse.repository.jpa;
 
+import com.valanse.valanse.entity.Quiz;
 import com.valanse.valanse.entity.UserAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserAnswerRepository extends JpaRepository<UserAnswer, Integer> {
+
+    List<Quiz> findByUserIdAndPreferenceGreaterThanEqual(Integer userId, int preference);
 }

--- a/src/main/java/com/valanse/valanse/service/QuizService/QuizNotFoundException.java
+++ b/src/main/java/com/valanse/valanse/service/QuizService/QuizNotFoundException.java
@@ -1,0 +1,7 @@
+package com.valanse.valanse.service.QuizService;
+
+public class QuizNotFoundException extends RuntimeException {
+    public QuizNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/valanse/valanse/service/QuizService/QuizService.java
+++ b/src/main/java/com/valanse/valanse/service/QuizService/QuizService.java
@@ -9,11 +9,24 @@ import java.util.List;
 import java.util.Optional;
 
 public interface QuizService {
-    List<Quiz> getUserPreferences(Integer userId, int preference); // 사용자가 선호도 준 퀴즈 조회
-    Optional<Integer> getQuizPreferenceSum(Integer quizId); // 퀴즈의 선호도 합 조회
-    Optional<Integer> getRecentActivity(Quiz quiz); // 퀴즈의 최근 활동(댓글 수, 조회수 등) 조회
+
+    QuizDto getQuiz(Integer quizId);
+
+    void increasePreference(Integer quizId, int preference); // 퀴즈의 선호도 증가
+
+    void increaseComment(Integer quizId); // 퀴즈의 댓글 수 증가
+
+    Optional<Integer> getQuizPreference(Integer quizId); // 퀴즈의 선호도 조회
+
+    Optional<Integer> getViewsCount(Integer quizId); // 퀴즈의 조회수 조회
+
+    Optional<Integer> getCommentsCount(Integer quizId); // 퀴즈의 댓글 수 조회
+
     List<Quiz> sortQuizByCreatedAt(); // 생성 시간에 따른 퀴즈 정렬
+
     List<Quiz> sortQuizByPreference(); // 선호도에 따른 퀴즈 정렬
+
     List<Quiz> searchQuiz(String keyword); // 퀴즈 검색
+
     void saveUserAnswer(UserAnswerDto userAnswer); // 클라이언트의 답변을 데이터베이스에 저장
 }

--- a/src/main/java/com/valanse/valanse/service/QuizService/QuizService.java
+++ b/src/main/java/com/valanse/valanse/service/QuizService/QuizService.java
@@ -14,13 +14,9 @@ public interface QuizService {
 
     void increasePreference(Integer quizId, int preference); // 퀴즈의 선호도 증가
 
-    void increaseComment(Integer quizId); // 퀴즈의 댓글 수 증가
-
     Optional<Integer> getQuizPreference(Integer quizId); // 퀴즈의 선호도 조회
 
     Optional<Integer> getViewsCount(Integer quizId); // 퀴즈의 조회수 조회
-
-    Optional<Integer> getCommentsCount(Integer quizId); // 퀴즈의 댓글 수 조회
 
     List<Quiz> sortQuizByCreatedAt(); // 생성 시간에 따른 퀴즈 정렬
 

--- a/src/main/java/com/valanse/valanse/service/QuizService/QuizServicelmpl.java
+++ b/src/main/java/com/valanse/valanse/service/QuizService/QuizServicelmpl.java
@@ -1,5 +1,6 @@
 package com.valanse.valanse.service.QuizService;
 
+import ch.qos.logback.classic.Logger;
 import com.valanse.valanse.dto.QuizDto;
 import com.valanse.valanse.dto.UserAnswerDto;
 import com.valanse.valanse.entity.Quiz;
@@ -16,16 +17,15 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class QuizServicelmpl implements QuizService {
 
-    @Autowired
     private final QuizRepository quizRepository;
+    private Logger log;
 
     @Override
     public QuizDto getQuiz(Integer quizId) {
-        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
-        if(optionalQuiz.isPresent()) {
-            Quiz quiz = optionalQuiz.get();
-            quiz.incrementViews(); // 조회수 증가
-            quizRepository.save(quiz);
+        try {
+            Quiz quiz = quizRepository.findById(quizId)
+                    .orElseThrow(() -> new QuizNotFoundException("Quiz not found with id: " + quizId));
+            quizRepository.increaseView(quizId); // 조회수 증가
             return QuizDto.builder()
                     .quizId(quiz.getQuizId())
                     .authorUserId(quiz.getAuthorUserId())
@@ -36,65 +36,45 @@ public class QuizServicelmpl implements QuizService {
                     .descriptionB(quiz.getDescriptionB())
                     .createdAt(quiz.getCreatedAt())
                     .build();
-        } else {
-            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        } catch (Exception e) {
+            log.error("Error retrieving quiz with id {}: {}", quizId, e.getMessage(), e);
+            throw e;
         }
     }
 
     @Override
     public void increasePreference(Integer quizId, int preference) {
-        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
-        if(optionalQuiz.isPresent()) {
-            Quiz quiz = optionalQuiz.get();
-            quiz.incrementPreference(preference); // 선호도 수 증가
-            quizRepository.save(quiz);
-        } else {
-            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
-        }
-    }
-
-    @Override
-    public void increaseComment(Integer quizId) {
-        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
-        if(optionalQuiz.isPresent()) {
-            Quiz quiz = optionalQuiz.get();
-            quiz.incrementComments(); // 댓글 수 증가
-            quizRepository.save(quiz);
-        } else {
-            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        try {
+            Quiz quiz = quizRepository.findById(quizId)
+                    .orElseThrow(() -> new QuizNotFoundException("Quiz not found with id: " + quizId));
+            quizRepository.increasePreference(quizId, preference); // 선호도 수 증가
+        } catch (Exception e) {
+            log.error("Error retrieving quiz with id {}: {}", quizId, e.getMessage(), e);
+            throw e;
         }
     }
 
     @Override
     public Optional<Integer> getQuizPreference(Integer quizId) {
-        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
-        if(optionalQuiz.isPresent()) {
-            Quiz quiz = optionalQuiz.get();
-            return Optional.ofNullable(quiz.getPreference());
-        } else {
-            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        try {
+            return quizRepository.findById(quizId)
+                    .map(Quiz::getPreference)
+                    .orElseThrow(() -> new QuizNotFoundException("Quiz not found with id: " + quizId)).describeConstable();
+        } catch (Exception e) {
+            log.error("Error retrieving quiz with id {}: {}", quizId, e.getMessage(), e);
+            throw e;
         }
     }
 
     @Override
     public Optional<Integer> getViewsCount(Integer quizId) {
-        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
-        if(optionalQuiz.isPresent()) {
-            Quiz quiz = optionalQuiz.get();
-            return Optional.ofNullable(quiz.getView());
-        } else {
-            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
-        }
-    }
-
-    @Override
-    public Optional<Integer> getCommentsCount(Integer quizId) {
-        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
-        if(optionalQuiz.isPresent()) {
-            Quiz quiz = optionalQuiz.get();
-            return Optional.ofNullable(quiz.getComment());
-        } else {
-            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        try {
+            return quizRepository.findById(quizId)
+                    .map(Quiz::getView)
+                    .orElseThrow(() -> new QuizNotFoundException("Quiz not found with id: " + quizId)).describeConstable();
+        } catch (Exception e) {
+            log.error("Error retrieving quiz with id {}: {}", quizId, e.getMessage(), e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/valanse/valanse/service/QuizService/QuizServicelmpl.java
+++ b/src/main/java/com/valanse/valanse/service/QuizService/QuizServicelmpl.java
@@ -1,0 +1,120 @@
+package com.valanse.valanse.service.QuizService;
+
+import com.valanse.valanse.dto.QuizDto;
+import com.valanse.valanse.dto.UserAnswerDto;
+import com.valanse.valanse.entity.Quiz;
+import com.valanse.valanse.entity.UserAnswer;
+import com.valanse.valanse.repository.jpa.QuizRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class QuizServicelmpl implements QuizService {
+
+    @Autowired
+    private final QuizRepository quizRepository;
+
+    @Override
+    public QuizDto getQuiz(Integer quizId) {
+        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
+        if(optionalQuiz.isPresent()) {
+            Quiz quiz = optionalQuiz.get();
+            quiz.incrementViews(); // 조회수 증가
+            quizRepository.save(quiz);
+            return QuizDto.builder()
+                    .quizId(quiz.getQuizId())
+                    .authorUserId(quiz.getAuthorUserId())
+                    .content(quiz.getContent())
+                    .optionA(quiz.getOptionA())
+                    .optionB(quiz.getOptionB())
+                    .descriptionA(quiz.getDescriptionA())
+                    .descriptionB(quiz.getDescriptionB())
+                    .createdAt(quiz.getCreatedAt())
+                    .build();
+        } else {
+            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        }
+    }
+
+    @Override
+    public void increasePreference(Integer quizId, int preference) {
+        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
+        if(optionalQuiz.isPresent()) {
+            Quiz quiz = optionalQuiz.get();
+            quiz.incrementPreference(preference); // 선호도 수 증가
+            quizRepository.save(quiz);
+        } else {
+            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        }
+    }
+
+    @Override
+    public void increaseComment(Integer quizId) {
+        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
+        if(optionalQuiz.isPresent()) {
+            Quiz quiz = optionalQuiz.get();
+            quiz.incrementComments(); // 댓글 수 증가
+            quizRepository.save(quiz);
+        } else {
+            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        }
+    }
+
+    @Override
+    public Optional<Integer> getQuizPreference(Integer quizId) {
+        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
+        if(optionalQuiz.isPresent()) {
+            Quiz quiz = optionalQuiz.get();
+            return Optional.ofNullable(quiz.getPreference());
+        } else {
+            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        }
+    }
+
+    @Override
+    public Optional<Integer> getViewsCount(Integer quizId) {
+        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
+        if(optionalQuiz.isPresent()) {
+            Quiz quiz = optionalQuiz.get();
+            return Optional.ofNullable(quiz.getView());
+        } else {
+            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        }
+    }
+
+    @Override
+    public Optional<Integer> getCommentsCount(Integer quizId) {
+        Optional<Quiz> optionalQuiz = quizRepository.findById(quizId);
+        if(optionalQuiz.isPresent()) {
+            Quiz quiz = optionalQuiz.get();
+            return Optional.ofNullable(quiz.getComment());
+        } else {
+            throw new QuizNotFoundException("Quiz not found with id: " + quizId);
+        }
+    }
+
+    @Override
+    public List<Quiz> sortQuizByCreatedAt() {
+        return quizRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    @Override
+    public List<Quiz> sortQuizByPreference() {
+        return quizRepository.findAllByOrderByPreferenceDesc();
+    }
+
+    @Override
+    public List<Quiz> searchQuiz(String keyword) {
+        return quizRepository.findByContentContaining(keyword);
+    }
+
+    @Override
+    public void saveUserAnswer(UserAnswerDto userAnswer) {
+
+    }
+}

--- a/src/main/java/com/valanse/valanse/service/UserAnswerService/UserAnswerService.java
+++ b/src/main/java/com/valanse/valanse/service/UserAnswerService/UserAnswerService.java
@@ -1,0 +1,11 @@
+package com.valanse.valanse.service.UserAnswerService;
+
+import com.valanse.valanse.entity.Quiz;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserAnswerService {
+
+    List<Quiz> getUserPreferences(Integer userId, int preference); // 사용자가 선호도 준 퀴즈 조회
+}

--- a/src/main/java/com/valanse/valanse/service/UserAnswerService/UserAnswerServicelmpl.java
+++ b/src/main/java/com/valanse/valanse/service/UserAnswerService/UserAnswerServicelmpl.java
@@ -1,0 +1,23 @@
+package com.valanse.valanse.service.UserAnswerService;
+
+import com.valanse.valanse.entity.Quiz;
+import com.valanse.valanse.repository.jpa.UserAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAnswerServicelmpl implements UserAnswerService {
+
+    @Autowired
+    private UserAnswerRepository userAnswerRepository;
+
+    @Override
+    public List<Quiz> getUserPreferences(Integer userId, int preference) {
+        return userAnswerRepository.findByUserIdAndPreferenceGreaterThanEqual(userId, preference);
+    }
+}

--- a/src/main/java/com/valanse/valanse/service/UserAnswerService/UserAnswerServicelmpl.java
+++ b/src/main/java/com/valanse/valanse/service/UserAnswerService/UserAnswerServicelmpl.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class UserAnswerServicelmpl implements UserAnswerService {
 
-    @Autowired
     private UserAnswerRepository userAnswerRepository;
 
     @Override

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -46,6 +46,9 @@ CREATE TABLE `quiz`
     `option_b`       VARCHAR(255) NOT NULL COMMENT '선택지 B',
     `description_a`         TEXT COMMENT 'A 설명',
     `description_b`         TEXT COMMENT 'B 설명',
+    `view`           INT          NOT NULL '조회수',
+    `comment`        INT          NOT NULL '댓글 수',
+    `preference`     INT          NOT NULL '선호도 수',
     `created_at`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '질문 생성 시간',
     `updated_at`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '질문 수정 시간',
     FOREIGN KEY (`author_user_id`) REFERENCES `user` (`user_id`)

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -46,9 +46,6 @@ CREATE TABLE `quiz`
     `option_b`       VARCHAR(255) NOT NULL COMMENT '선택지 B',
     `description_a`         TEXT COMMENT 'A 설명',
     `description_b`         TEXT COMMENT 'B 설명',
-    `view`           INT          NOT NULL '조회수',
-    `comment`        INT          NOT NULL '댓글 수',
-    `preference`     INT          NOT NULL '선호도 수',
     `created_at`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '질문 생성 시간',
     `updated_at`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '질문 수정 시간',
     FOREIGN KEY (`author_user_id`) REFERENCES `user` (`user_id`)


### PR DESCRIPTION
음 일단 퀴즈의 선호도를 증가하는 기능(increasePreference 메서드), 퀴즈의 댓글 수를 증가하는 기능(increaseComment 메서드)을 추가로 구현했고 클라이언트의 답변을 데이터베이스에 저장하는 기능인 saveUserAnswer 메서드는 아직 구현 못했습니다.
조회수 증가는 getQuiz 메서드에서 퀴즈를 조회할 때 조회수를 증가하게 했습니다. 그리고 사용자가 선호도를 준 퀴즈를 조회하는 기능인 getUserPreferences 메서드는 UserAnswer와 더 어울리는 거 같아 UserAnswerService 구현체에 구현하였습니다. 근데 이게 재중님이 ddl alter하기 싫다고 하셨는데 퀴즈의 선호도 수나 조회수나 댓글 수를 조회하려고 하면 Quiz 엔터티에 퀴즈의 선호도 수, 조회수, 댓글 수를 추가해야 할 거 같은데 어떡하지요.. 그리고 한 줄로 끝나는 기능들도 좀 있습니다.