### PR TITLE
Asha

### DIFF
--- a/src/main/java/com/valanse/valanse/controller/NoticeController.java
+++ b/src/main/java/com/valanse/valanse/controller/NoticeController.java
@@ -1,0 +1,97 @@
+package com.valanse.valanse.controller;
+
+import com.valanse.valanse.dto.NoticeRegisterDto;
+import com.valanse.valanse.dto.StatusResponseDto;
+import com.valanse.valanse.service.NoticeService.NoticeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notice")
+@Tag(name = "Notice Controller", description = "공지사항 관련 API를 관리합니다.")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Operation(summary = "공지사항을 등록합니다.",
+            description = "공지사항의 제목, 내용을 등록하여 새로운 공지사항을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "등록 성공", content = @Content(schema = @Schema(implementation = StatusResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
+            @ApiResponse(responseCode = "403", description = "해당 작업에 대한 권한 없음"),
+            @ApiResponse(responseCode = "409", description = "필수 항목 불입력")
+    })
+    @PostMapping("/register")
+    public ResponseEntity<StatusResponseDto> registerNotice(
+            @Parameter(description = "HTTP 요청 객체", hidden = true)
+            HttpServletRequest httpServletRequest,
+            @Parameter(description = "공지사항 등록에 필요한 데이터", required = true, schema = @Schema(implementation = NoticeRegisterDto.class))
+            @RequestPart NoticeRegisterDto noticeRegisterDto
+    ) {
+        noticeService.registerNotice(httpServletRequest, noticeRegisterDto);
+
+        return ResponseEntity.ok(StatusResponseDto.success("notice register successfully"));
+    }
+
+    @Operation(summary = "특정 공지사항을 조회합니다.",
+            description = "지정된 ID로 공지사항 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = StatusResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 ID로 공지사항을 찾을 수 없음")
+    })
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<StatusResponseDto> getNotice(@PathVariable("noticeId") Integer noticeId) {
+        return ResponseEntity.ok(StatusResponseDto.success(noticeService.getNotice(noticeId)));
+    }
+
+    @Operation(summary = "특정 공지사항을 갱신합니다.",
+            description = "지정된 ID, 공지사항의 제목, 내용으로 공지사항을 갱신합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "갱신 성공", content = @Content(schema = @Schema(implementation = StatusResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
+            @ApiResponse(responseCode = "403", description = "해당 작업에 대한 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "해당 ID로 공지사항을 찾을 수 없음")
+    })
+    @PatchMapping("/{noticeId}")
+    public ResponseEntity<StatusResponseDto> updateNotice(
+            @Parameter(description = "HTTP 요청 객체", hidden = true)
+            HttpServletRequest httpServletRequest,
+            @PathVariable("noticeId") Integer noticeId,
+            @Parameter(description = "공지사항 갱신에 필요한 데이터", required = true, schema = @Schema(implementation = NoticeRegisterDto.class))
+            @RequestPart NoticeRegisterDto noticeRegisterDto
+    ) {
+        noticeService.updateNotice(httpServletRequest, noticeId, noticeRegisterDto);
+
+        return ResponseEntity.ok(StatusResponseDto.success("notice updated successfully"));
+    }
+
+    @Operation(summary = "특정 공지사항을 삭제합니다.",
+            description = "지정된 ID로 공지사항을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공", content = @Content(schema = @Schema(implementation = StatusResponseDto.class))),
+            @ApiResponse(responseCode = "403", description = "해당 작업에 대한 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "해당 ID로 공지사항을 찾을 수 없음")
+    })
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<StatusResponseDto> deleteNotice(
+            @Parameter(description = "HTTP 요청 객체", hidden = true)
+            HttpServletRequest httpServletRequest,
+            @PathVariable("noticeId") Integer noticeId
+    ) {
+        noticeService.deleteNotice(httpServletRequest, noticeId);
+
+        return ResponseEntity.ok(StatusResponseDto.success("notice deleted successfully"));
+    }
+}

--- a/src/main/java/com/valanse/valanse/controller/QuizCategoryController.java
+++ b/src/main/java/com/valanse/valanse/controller/QuizCategoryController.java
@@ -2,7 +2,6 @@ package com.valanse.valanse.controller;
 
 import com.valanse.valanse.dto.QuizCategoryStatsDto;
 import com.valanse.valanse.dto.StatusResponseDto;
-import com.valanse.valanse.entity.QuizCategory;
 import com.valanse.valanse.service.QuizCategoryService.QuizCategoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,8 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/valanse/valanse/controller/QuizController.java
+++ b/src/main/java/com/valanse/valanse/controller/QuizController.java
@@ -46,6 +46,7 @@ public class QuizController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "등록 성공", content = @Content(schema = @Schema(implementation = StatusResponseDto.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
+            @ApiResponse(responseCode = "409", description = "필수 항목 불입력"),
             @ApiResponse(responseCode = "500", description = "서버 오류로 인해 퀴즈 등록 실패")
     })
     @PostMapping("/register")
@@ -80,7 +81,7 @@ public class QuizController {
             @Parameter(description = "HTTP 요청 객체", hidden = true)
             HttpServletRequest httpServletRequest,
             @PathVariable("quizId") Integer quizId,
-            @Parameter(description = "퀴즈 갱신에 필요한 데이터", schema = @Schema(implementation = QuizController.class))
+            @Parameter(description = "퀴즈 갱신에 필요한 데이터", schema = @Schema(implementation = QuizRegisterDto.class))
             @RequestPart QuizRegisterDto quizRegisterDto,
             @Parameter(description = "옵션 A에 대한 이미지")
             @RequestPart MultipartFile image_A,
@@ -190,7 +191,8 @@ public class QuizController {
             description = "사용자의 답변을 데이터베이스에 저장")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "저장 성공", content = @Content(schema = @Schema(implementation = StatusResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
+            @ApiResponse(responseCode = "409", description = "필수 항목 불입력")
     })
     @PostMapping("/save-user-answer")
     public ResponseEntity<StatusResponseDto> saveUserAnswer(

--- a/src/main/java/com/valanse/valanse/controller/QuizController.java
+++ b/src/main/java/com/valanse/valanse/controller/QuizController.java
@@ -3,9 +3,7 @@ package com.valanse.valanse.controller;
 import com.valanse.valanse.dto.QuizRegisterDto;
 import com.valanse.valanse.dto.QuizStatsDto;
 import com.valanse.valanse.dto.StatusResponseDto;
-import com.valanse.valanse.service.QuizService.QuizService;
 import com.valanse.valanse.dto.UserAnswerDto;
-import com.valanse.valanse.entity.Quiz;
 import com.valanse.valanse.service.QuizService.QuizService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,7 +20,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/valanse/valanse/dto/NoticeDto.java
+++ b/src/main/java/com/valanse/valanse/dto/NoticeDto.java
@@ -1,0 +1,26 @@
+package com.valanse.valanse.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoticeDto {
+    private Integer noticeId;
+
+    private String title;
+
+    private String content;
+
+    private Integer authorId;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Integer views;
+}

--- a/src/main/java/com/valanse/valanse/dto/NoticeRegisterDto.java
+++ b/src/main/java/com/valanse/valanse/dto/NoticeRegisterDto.java
@@ -1,0 +1,14 @@
+package com.valanse.valanse.dto;
+
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoticeRegisterDto {
+    private String title;
+
+    private String content;
+}

--- a/src/main/java/com/valanse/valanse/entity/Notice.java
+++ b/src/main/java/com/valanse/valanse/entity/Notice.java
@@ -1,0 +1,29 @@
+package com.valanse.valanse.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer noticeId;
+
+    private String title;
+
+    private String content;
+
+    private Integer authorId;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Integer views;
+}

--- a/src/main/java/com/valanse/valanse/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/valanse/valanse/exception/GlobalExceptionHandler.java
@@ -209,19 +209,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(MissingServletRequestPartException.class)
-    public ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
-        log.error("Required request part is missing", e);
-
-        ErrorResponse errorResponse = new ErrorResponse(
-                LocalDateTime.now(),
-                HttpStatus.BAD_REQUEST.value(),
-                "Missing Request Part",
-                e.getMessage(),
-                "Required request part is missing");
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-    }
-
     @ExceptionHandler(MultipartException.class)
     public ResponseEntity<ErrorResponse> handleMultipartException(MultipartException e, WebRequest request) {
         log.error("Failed to process multipart request", e);
@@ -230,19 +217,6 @@ public class GlobalExceptionHandler {
                 LocalDateTime.now(),
                 HttpStatus.BAD_REQUEST.value(),
                 "Failed to process multipart request",
-                e.getMessage(),
-                request.getDescription(false));
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(NullPointerException.class)
-    public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e, WebRequest request) {
-        log.error("NullPointerException occurred: {}", e.getMessage(), e);
-
-        ErrorResponse errorResponse = new ErrorResponse(
-                LocalDateTime.now(),
-                HttpStatus.BAD_REQUEST.value(),
-                "Required data is missing.",
                 e.getMessage(),
                 request.getDescription(false));
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/valanse/valanse/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/valanse/valanse/exception/GlobalExceptionHandler.java
@@ -209,6 +209,19 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
+        log.error("Required request part is missing", e);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Missing Request part",
+                e.getMessage(),
+                "Required request part is missing");
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(MultipartException.class)
     public ResponseEntity<ErrorResponse> handleMultipartException(MultipartException e, WebRequest request) {
         log.error("Failed to process multipart request", e);

--- a/src/main/java/com/valanse/valanse/redis/config/RedisConfig.java
+++ b/src/main/java/com/valanse/valanse/redis/config/RedisConfig.java
@@ -21,15 +21,15 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
-//    @Value("${spring.data.redis.password}")
-//    private String password;
+    @Value("${spring.data.redis.password}")
+    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(host);
         redisStandaloneConfiguration.setPort(port);
-        //redisStandaloneConfiguration.setPassword(password); // 비밀번호 설정
+        redisStandaloneConfiguration.setPassword(password); // 비밀번호 설정
 
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }

--- a/src/main/java/com/valanse/valanse/repository/jpa/NoticeRepository.java
+++ b/src/main/java/com/valanse/valanse/repository/jpa/NoticeRepository.java
@@ -1,0 +1,16 @@
+package com.valanse.valanse.repository.jpa;
+
+import com.valanse.valanse.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Integer> {
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Notice n SET n.views = n.views + 1 WHERE n.noticeId = :noticeId")
+    void increaseView(@Param("noticeId") Integer noticeId);
+}

--- a/src/main/java/com/valanse/valanse/service/NoticeService/NoticeService.java
+++ b/src/main/java/com/valanse/valanse/service/NoticeService/NoticeService.java
@@ -1,0 +1,15 @@
+package com.valanse.valanse.service.NoticeService;
+
+import com.valanse.valanse.dto.NoticeDto;
+import com.valanse.valanse.dto.NoticeRegisterDto;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface NoticeService {
+    void registerNotice(HttpServletRequest httpServletRequest, NoticeRegisterDto noticeRegisterDto);
+
+    NoticeDto getNotice(Integer noticeId);
+
+    void updateNotice(HttpServletRequest httpServletRequest, Integer noticeId, NoticeRegisterDto noticeRegisterDto);
+
+    void deleteNotice(HttpServletRequest httpServletRequest, Integer noticeId);
+}

--- a/src/main/java/com/valanse/valanse/service/NoticeService/NoticeServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/NoticeService/NoticeServiceImpl.java
@@ -1,0 +1,121 @@
+package com.valanse.valanse.service.NoticeService;
+
+import com.valanse.valanse.dto.NoticeDto;
+import com.valanse.valanse.dto.NoticeRegisterDto;
+import com.valanse.valanse.entity.Notice;
+import com.valanse.valanse.repository.jpa.NoticeRepository;
+import com.valanse.valanse.security.util.JwtUtil;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NoticeServiceImpl implements NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void registerNotice(HttpServletRequest httpServletRequest, NoticeRegisterDto noticeRegisterDto) {
+        try {
+            int userIdx = jwtUtil.getUserIdxFromRequest(httpServletRequest);
+
+            String token = jwtUtil.getAccessTokenFromRequest(httpServletRequest);
+            String userRole = jwtUtil.getUserRole(token);
+
+            // 'role' 이 'admin' 이 아니면 예외 처리
+            if (!"admin".equals(userRole)) {
+                throw new AccessDeniedException("User does not have permission to register notices.");
+            }
+
+            Notice notice = Notice.builder()
+                    .title(noticeRegisterDto.getTitle())
+                    .content(noticeRegisterDto.getContent())
+                    .authorId(userIdx)
+                    .createdAt(LocalDateTime.now())
+                    .views(0)
+                    .build();
+
+            noticeRepository.save(notice);
+        } catch (AccessDeniedException e) {
+            log.error("User does not have permission to register notices.", e);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public NoticeDto getNotice(Integer noticeId) {
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow(EntityNotFoundException::new);
+
+        noticeRepository.increaseView(notice.getNoticeId());
+
+        return NoticeDto.builder()
+                .noticeId(notice.getNoticeId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .authorId(notice.getAuthorId())
+                .createdAt(notice.getCreatedAt())
+                .updatedAt(notice.getUpdatedAt())
+                .views(notice.getViews())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateNotice(HttpServletRequest httpServletRequest, Integer noticeId, NoticeRegisterDto noticeRegisterDto) {
+        try {
+            String token = jwtUtil.getAccessTokenFromRequest(httpServletRequest);
+            String userRole = jwtUtil.getUserRole(token);
+
+            Notice existingNotice = noticeRepository.findById(noticeId).orElseThrow(EntityNotFoundException::new);
+
+            if (!"admin".equals(userRole)) {
+                throw new AccessDeniedException("User does not have permission to update notices.");
+            }
+
+            existingNotice = Notice.builder()
+                    .noticeId(existingNotice.getNoticeId())
+                    .title(noticeRegisterDto.getTitle() != null ? noticeRegisterDto.getTitle() : existingNotice.getTitle())
+                    .content(noticeRegisterDto.getContent() != null ? noticeRegisterDto.getContent() : existingNotice.getContent())
+                    .authorId(existingNotice.getAuthorId())
+                    .createdAt(existingNotice.getCreatedAt())
+                    .updatedAt(LocalDateTime.now())
+                    .views(existingNotice.getViews())
+                    .build();
+
+            noticeRepository.save(existingNotice);
+        } catch (AccessDeniedException e) {
+            log.error("User does not have permission to update notices.", e);
+            throw e;
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteNotice(HttpServletRequest httpServletRequest, Integer noticeId) {
+        try {
+            String token = jwtUtil.getAccessTokenFromRequest(httpServletRequest);
+            String userRole = jwtUtil.getUserRole(token);
+
+            Notice notice = noticeRepository.findById(noticeId).orElseThrow(EntityNotFoundException::new);
+
+            if (!"admin".equals(userRole)) {
+                throw new AccessDeniedException("User does not have permission to delete notices.");
+            }
+
+            noticeRepository.delete(notice);
+        } catch (AccessDeniedException e) {
+            log.error("User does not have permission to delete notices.", e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/valanse/valanse/service/QuizService/QuizServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/QuizService/QuizServiceImpl.java
@@ -61,7 +61,10 @@ public class QuizServiceImpl implements QuizService {
                 .optionB(quiz.getOptionB())
                 .descriptionA(quiz.getDescriptionA())
                 .descriptionB(quiz.getDescriptionB())
-                .createdAt(LocalDateTime.now())
+                .view(quiz.getView())
+                .preference(quiz.getPreference())
+                .createdAt(quiz.getCreatedAt())
+                .updatedAt(quiz.getUpdatedAt())
                 .build();
     }
 
@@ -77,11 +80,11 @@ public class QuizServiceImpl implements QuizService {
         String path_A = null;
         String path_B = null;
 
-        if (image_A != null) {
+        if (image_A != null && !image_A.isEmpty()) {
             path_A = s3ImageService.uploadImage(image_A);
         }
 
-        if (image_B != null) {
+        if (image_B != null && !image_B.isEmpty()) {
             path_B = s3ImageService.uploadImage(image_B);
         }
 
@@ -129,11 +132,11 @@ public class QuizServiceImpl implements QuizService {
             String imagePathA = null;
             String imagePathB = null;
 
-            if (image_A != null) {
+            if (image_A != null && !image_A.isEmpty()) {
                 imagePathA = s3ImageService.uploadImage(image_A);
             }
 
-            if (image_B != null) {
+            if (image_B != null && !image_B.isEmpty()) {
                 imagePathB = s3ImageService.uploadImage(image_B);
             }
 


### PR DESCRIPTION
getAccessTokenFromRequest 메서드로 토큰을 가져온 후 가져온 토큰을 getUserRole 메서드로 role을 가져와 role이 admin이 아니면 AccessDeniedException을 던져 예외 처리

registerNotice - 사용자로부터 noticeRegisterDto의 title, content를 입력받아 공지사항을 만듦
required = true인 noticeRegisterDto가 비어있으면 400 에러, ddl에서 not null의 값인 noticeRegisterDto의 title이나 content 값이 비어있으면 409 에러

updateNotice - noticeId로 Notice Entity를 조회해 사용자로부터 입력받은 title, content로 수정하고 둘 중 입력받지 못하는 값이 있으면 기존 db에 저장된 값으로 유지
required = true인 noticeRegisterDto가 비어있으면 400 에러; 입력받지 못하면 기존의 값으로 유지되므로 409 에러는 발생하지 않음